### PR TITLE
✨ Spanner instance and databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # 🔖 Changelog
 
 ## Unreleased
+
+Features:
+
+- Implement the first version of the Spanner databases module, managing a Spanner instance, its databases, and their DDLs.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # Terraform module for Spanner database management
+
+This module manages a Spanner instance and its child databases, along with their DDLs. It relies on the [`ProjectWriteConfigurations`](https://github.com/causa-io/workspace-module-core#projectwriteconfigurations) and [`GoogleSpannerWriteDatabases`](https://github.com/causa-io/workspace-module-google#googlespannerwritedatabases) infrastructure processor to generate the configuration for the instance and the databases.
+
+## ➕ Requirements
+
+This module depends on the [google Terraform provider](https://registry.terraform.io/providers/hashicorp/google/latest).
+
+## 🎉 Installation
+
+Copy the following in your Terraform configuration, and run `terraform init`:
+
+```terraform
+module "my_service" {
+  source  = "causa-io/spanner-databases/google"
+  version = "<insert the most recent version number here>"
+
+  # The path to the generated configuration file for the infrastructure project.
+  infrastructure_configuration_file = "${local.project_configurations_directory}/infrastructure.json"
+  # The path to the generated database configurations.
+  databases_directory               = "${local.causa_directory}/spanner-databases"
+}
+```
+
+## ✨ Features
+
+### Spanner instance
+
+This module creates and manages a Spanner instance. Its configuration can be loaded from the `google.spanner.instance` configuration in the infrastructure project (or its parent workspace configuration), which should be set in the `infrastructure_configuration_file` Terraform variable. The configuration can also be overridden using standard Terraform variables, see the descriptions in the [corresponding file](./variables.tf).
+
+### Spanner databases
+
+A Spanner database is created and managed for each database configuration file written by the [`GoogleSpannerWriteDatabases`](https://github.com/causa-io/workspace-module-google#googlespannerwritedatabases) processor at the location set in the `databases_directory` Terraform variable. The databases are found in the workspace as defined in the `google.spanner.ddls` configuration.
+
+### Deletion protection
+
+The `deletion_protection` Terraform variable defaults to `true` and protects both the instance and its databases. It can be set to `false` when it is okay to delete the databases (e.g. in development environments).

--- a/databases.tf
+++ b/databases.tf
@@ -1,0 +1,21 @@
+locals {
+  database_configuration_files = [
+    for configuration in fileset(var.databases_directory, "*.{json,yaml}") :
+    yamldecode(file("${var.databases_directory}/${configuration}"))
+  ]
+  database_configurations = {
+    for configuration in local.database_configuration_files :
+    configuration.id => configuration
+  }
+}
+
+# The Spanner database for each configuration.
+resource "google_spanner_database" "database" {
+  for_each = local.database_configurations
+
+  instance = google_spanner_instance.instance.name
+  name     = each.value.id
+  ddl      = each.value.ddls
+
+  deletion_protection = var.deletion_protection
+}

--- a/instance.tf
+++ b/instance.tf
@@ -1,0 +1,10 @@
+# The Spanner instance for all databases.
+resource "google_spanner_instance" "instance" {
+  project          = local.gcp_project_id
+  config           = local.instance_configuration
+  name             = local.instance_name
+  display_name     = local.instance_name
+  processing_units = local.instance_processing_units
+
+  force_destroy = !var.deletion_protection
+}

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,18 @@
+locals {
+  # Project configuration from the JSON file.
+  configuration = yamldecode(file(var.infrastructure_configuration_file))
 
+  conf_google                    = try(local.configuration.google, tomap({}))
+  conf_google_project            = try(local.conf_google.project, null)
+  conf_spanner                   = try(local.conf_google.spanner, tomap({}))
+  conf_spanner_instance          = try(local.conf_spanner.instance, tomap({}))
+  conf_instance_name             = try(local.conf_spanner_instance.name, null)
+  conf_instance_configuration    = try(local.conf_spanner_instance.configuration, null)
+  conf_instance_processing_units = try(local.conf_spanner_instance.processingUnits, null)
+
+  # Configuration with variable overrides.
+  gcp_project_id            = coalesce(var.gcp_project_id, local.conf_google_project)
+  instance_name             = coalesce(var.instance_name, local.conf_instance_name)
+  instance_configuration    = coalesce(var.instance_configuration, local.conf_instance_configuration)
+  instance_processing_units = coalesce(var.instance_processing_units, local.conf_instance_processing_units)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,4 @@
-
+output "instance_name" {
+  description = "The name of the Cloud Spanner instance."
+  value       = google_spanner_instance.instance.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,19 @@ output "instance_name" {
   description = "The name of the Cloud Spanner instance."
   value       = google_spanner_instance.instance.name
 }
+
+output "database_ids" {
+  description = "The ID of each Cloud Spanner database."
+  value = [
+    for id, database in google_spanner_database.database :
+    database.id
+  ]
+}
+
+output "database_ddls" {
+  description = "The DDL of each Cloud Spanner database. This can be used to express a reference dependency on a database, with a Cloud Run service or Cloud Function."
+  value = {
+    for id, database in google_spanner_database.database :
+    id => database.ddl
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "infrastructure_configuration_file" {
   description = "The path to the configuration file for the infrastructure project. It should be in JSON or YAML."
 }
 
+variable "databases_directory" {
+  type        = string
+  description = "The path to the directory containing the Spanner database configurations."
+}
+
 variable "gcp_project_id" {
   type        = string
   description = "The GCP project ID in which resources will be placed. Defaults to the `google.project` configuration."

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,34 @@
+variable "infrastructure_configuration_file" {
+  type        = string
+  description = "The path to the configuration file for the infrastructure project. It should be in JSON or YAML."
+}
 
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID in which resources will be placed. Defaults to the `google.project` configuration."
+  default     = null
+}
+
+variable "instance_name" {
+  type        = string
+  description = "The name of the Cloud Spanner instance. Defaults to the `google.spanner.instance.name` configuration."
+  default     = null
+}
+
+variable "instance_configuration" {
+  type        = string
+  description = "The name of the Cloud Spanner instance geographic configuration. Defaults to the `google.spanner.instance.configuration` configuration."
+  default     = null
+}
+
+variable "instance_processing_units" {
+  type        = number
+  description = "The number of processing units allocated to the Cloud Spanner instance. Defaults to the `google.spanner.instance.processingUnits` configuration."
+  default     = null
+}
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Whether the Cloud Spanner instance and its databases are protected against deletion. Defaults to `true`."
+  default     = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,1 +1,8 @@
-
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.75.0, < 5.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the first version of the module, managing a Spanner instance and its databases using the configurations written by Causa infrastructure processors.

### Commits

- ➕ Depend on the google Terraform provider
- ✨ Define the Spanner instance
- ✨ Define the Spanner databases
- 📝 Update changelog
- 📝 Document the module