### PR TITLE
🐛 Set the GCP project ID for Spanner databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Set the GCP project on the Spanner database resources according to the configuration.
+
 ## v0.1.0 (2023-07-28)
 
 Features:

--- a/databases.tf
+++ b/databases.tf
@@ -13,6 +13,7 @@ locals {
 resource "google_spanner_database" "database" {
   for_each = local.database_configurations
 
+  project  = local.gcp_project_id
   instance = google_spanner_instance.instance.name
   name     = each.value.id
   ddl      = each.value.ddls


### PR DESCRIPTION
The title says it all. This could have causes problems in very specific setups, although it would have worked in the nominal case (i.e. using the default project).

### Commits

- 🐛 Set the project for Spanner databases
- 📝 Update changelog