### PR TITLE
🔖 Prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.1.1 (2023-07-28)
+
 Fixes:
 
 - Set the GCP project on the Spanner database resources according to the configuration.


### PR DESCRIPTION
Fixes:

- Set the GCP project on the Spanner database resources according to the configuration.

### Commits

- 📝  Update changelog