### PR TITLE
✨ Database version retention period setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support setting the database version retention period for all databases.
+
 ## v0.2.0 (2024-05-24)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ module "my_databases" {
 
 A Spanner database is created and managed for each database configuration file written by the [`GoogleSpannerWriteDatabases`](https://github.com/causa-io/workspace-module-google#googlespannerwritedatabases) processor at the location set in the `databases_directory` Terraform variable. The databases are found in the workspace as defined in the `google.spanner.ddls` configuration.
 
+The [retention version period](https://cloud.google.com/spanner/docs/pitr) for all databases can be set using the `google.spanner.versionRetentionPeriod` configuration or the `database_version_retention_period` Terraform variable. If per-database configuration is needed, the version retention period should be defined in the database DDL instead.
+
 ### Deletion protection
 
 The `deletion_protection` Terraform variable defaults to `true` and protects both the instance and its databases. It can be set to `false` when it is okay to delete the databases (e.g. in development environments).

--- a/databases.tf
+++ b/databases.tf
@@ -18,5 +18,7 @@ resource "google_spanner_database" "database" {
   name     = each.value.id
   ddl      = each.value.ddls
 
+  version_retention_period = local.database_version_retention_period
+
   deletion_protection = var.deletion_protection
 }

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,8 @@ locals {
   conf_autoscaling_high_priority_cpu_utilization_target = try(local.conf_autoscaling.highPriorityCpuUtilizationTarget, null)
   conf_autoscaling_storage_utilization_target           = try(local.conf_autoscaling.storageUtilizationTarget, null)
 
+  conf_database_version_retention_period = try(local.conf_spanner.versionRetentionPeriod, null)
+
   # Configuration with variable overrides.
   gcp_project_id            = coalesce(var.gcp_project_id, local.conf_google_project)
   instance_name             = coalesce(var.instance_name, local.conf_instance_name)
@@ -30,4 +32,8 @@ locals {
       storage_utilization_target           = local.conf_autoscaling_storage_utilization_target
     }
   ) : null
+  database_version_retention_period = try(
+    coalesce(var.database_version_retention_period, local.conf_database_version_retention_period),
+    null,
+  )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "instance_processing_units" {
   default     = null
 }
 
+variable "database_version_retention_period" {
+  type        = string
+  description = "The retention period for the database. Defaults to the `google.spanner.versionRetentionPeriod` configuration. For database-level configuration, set the period in the DDL instead."
+  default     = null
+}
+
 variable "instance_autoscaling" {
   type = object({
     max_processing_units                 = optional(number)


### PR DESCRIPTION
This exposes the `version_retention_period` setting of the managed `google_spanner_database` resources.

A single value for all databases is supported, either through the `database_version_retention_period` Terraform variable or the `google.spanner.versionRetentionPeriod`.
If each database must have its own period, this can be set using a DDL statement instead.

### Commits

- **✨ Support a single version retention period for all databases**
- **📝 Document the retention version period feature**
- **📝 Update changelog**