### PR TITLE
⬆️ Upgrade compatible google provider versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Chores:
+
+- Upgrade compatible `google` provider versions to support `6.*.*`.
+
 ## v0.3.0 (2024-05-30)
 
 Features:

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.7.0, < 6.0"
+      version = ">= 5.7.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
The title says it all. The Google Terraform provider `v6.0.0` was recently released.

### Commits

- **⬆️ Upgrade compatible google provider versions**
- **📝 Update changelog**