### PR TITLE
🔖 Prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.1 (2024-08-30)
+
 Chores:
 
 - Upgrade compatible `google` provider versions to support `6.*.*`.


### PR DESCRIPTION
Chores:

- Upgrade compatible `google` provider versions to support `6.*.*`.

### Commits

- **📝 Update changelog**