### PR TITLE
⬆️ Bump `google` provider supported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Chores:
+
+- Upgrade compatible `google` provider versions to support `7.*.*`.
+
 ## v0.3.1 (2024-08-30)
 
 Chores:

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.7.0, < 7.0"
+      version = ">= 5.7.0, < 8.0"
     }
   }
 }


### PR DESCRIPTION
This is identical to https://github.com/causa-io/terraform-google-api-router/pull/9, to support version `7` of the `google` Terraform provider.