### PR TITLE
🔖 Prepare v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.2 (2025-09-12)
+
 Chores:
 
 - Upgrade compatible `google` provider versions to support `7.*.*`.


### PR DESCRIPTION
Chores:

- Upgrade compatible `google` provider versions to support `7.*.*`.