### PR TITLE
✨ Add support for Spanner instance edition attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support configuring the instance edition. Defaults to standard, unless autoscaling is enabled, in which case it defaults to enterprise.
+
 ## v0.3.2 (2025-09-12)
 
 Chores:

--- a/instance.tf
+++ b/instance.tf
@@ -4,6 +4,7 @@ resource "google_spanner_instance" "instance" {
   config       = local.instance_configuration
   name         = local.instance_name
   display_name = local.instance_name
+  edition      = local.instance_edition
 
   processing_units = local.instance_autoscaling == null ? local.instance_processing_units : null
 

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ locals {
   conf_autoscaling_min_processing_units                 = try(local.conf_autoscaling.minProcessingUnits, null)
   conf_autoscaling_high_priority_cpu_utilization_target = try(local.conf_autoscaling.highPriorityCpuUtilizationTarget, null)
   conf_autoscaling_storage_utilization_target           = try(local.conf_autoscaling.storageUtilizationTarget, null)
+  conf_instance_edition                                 = try(local.conf_spanner_instance.edition, null)
 
   conf_database_version_retention_period = try(local.conf_spanner.versionRetentionPeriod, null)
 
@@ -35,5 +36,10 @@ locals {
   database_version_retention_period = try(
     coalesce(var.database_version_retention_period, local.conf_database_version_retention_period),
     null,
+  )
+  instance_edition = coalesce(
+    var.instance_edition,
+    local.conf_instance_edition,
+    local.instance_autoscaling != null ? "ENTERPRISE" : "STANDARD",
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "instance_autoscaling" {
   default     = null
 }
 
+variable "instance_edition" {
+  type        = string
+  description = "The edition for the Cloud Spanner instance. Defaults to the `google.spanner.instance.edition` configuration. If not set, defaults to `STANDARD` when autoscaling is disabled, or `ENTERPRISE` when autoscaling is enabled."
+  default     = null
+}
+
 variable "deletion_protection" {
   type        = bool
   description = "Whether the Cloud Spanner instance and its databases are protected against deletion. Defaults to `true`."


### PR DESCRIPTION
This PR:

- Adds the `instance_edition` variable to configure the Cloud Spanner instance edition.
- Supports configuration via JSON/YAML at `google.spanner.instance.edition`.
- Defaults to `STANDARD` for fixed-capacity instances, `ENTERPRISE` for autoscaling instances.