### PR TITLE
🔖 Prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0 (2026-01-21)
+
 Features:
 
 - Support configuring the instance edition. Defaults to standard, unless autoscaling is enabled, in which case it defaults to enterprise.


### PR DESCRIPTION
Features:

- Support configuring the instance edition. Defaults to standard, unless autoscaling is enabled, in which case it defaults to enterprise.