### PR TITLE
✨ Support configuring a timeout for database DDL operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Support configuring a timeout for database create and update operations.
+
 ## v0.4.0 (2026-01-21)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ A Spanner database is created and managed for each database configuration file w
 
 The [retention version period](https://cloud.google.com/spanner/docs/pitr) for all databases can be set using the `google.spanner.versionRetentionPeriod` configuration or the `database_version_retention_period` Terraform variable. If per-database configuration is needed, the version retention period should be defined in the database DDL instead.
 
+### Database timeout
+
+Spanner DDL operations can sometimes take a long time to apply, which may cause Terraform to timeout. The timeout for create and update operations on database resources can be configured using the `google.spanner.databaseDdlTimeout` configuration or the `database_timeout` Terraform variable. It accepts a string duration, e.g. `"60m"`.
+
 ### Deletion protection
 
 The `deletion_protection` Terraform variable defaults to `true` and protects both the instance and its databases. It can be set to `false` when it is okay to delete the databases (e.g. in development environments).

--- a/databases.tf
+++ b/databases.tf
@@ -21,4 +21,13 @@ resource "google_spanner_database" "database" {
   version_retention_period = local.database_version_retention_period
 
   deletion_protection = var.deletion_protection
+
+  dynamic "timeouts" {
+    for_each = local.database_timeout != null ? [1] : []
+
+    content {
+      create = local.database_timeout
+      update = local.database_timeout
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ locals {
   conf_instance_edition                                 = try(local.conf_spanner_instance.edition, null)
 
   conf_database_version_retention_period = try(local.conf_spanner.versionRetentionPeriod, null)
+  conf_database_timeout                  = try(local.conf_spanner.databaseDdlTimeout, null)
 
   # Configuration with variable overrides.
   gcp_project_id            = coalesce(var.gcp_project_id, local.conf_google_project)
@@ -35,6 +36,10 @@ locals {
   ) : null
   database_version_retention_period = try(
     coalesce(var.database_version_retention_period, local.conf_database_version_retention_period),
+    null,
+  )
+  database_timeout = try(
+    coalesce(var.database_timeout, local.conf_database_timeout),
     null,
   )
   instance_edition = coalesce(

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "instance_edition" {
   default     = null
 }
 
+variable "database_timeout" {
+  type        = string
+  description = "The timeout for create and update operations on the Cloud Spanner databases. Defaults to the `google.spanner.databaseDdlTimeout` configuration. This can be increased for databases with DDLs that take a long time to apply."
+  default     = null
+}
+
 variable "deletion_protection" {
   type        = bool
   description = "Whether the Cloud Spanner instance and its databases are protected against deletion. Defaults to `true`."


### PR DESCRIPTION
Adds a `database_timeout` Terraform variable and `google.spanner.databaseDdlTimeout` Causa configuration to control the timeout for database create and update operations.

Spanner DDL operations can sometimes take a long time to apply, causing Terraform to timeout with default settings. This allows users to increase the timeout as needed.